### PR TITLE
add home page and repo path to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,15 @@
   "name": "async_work",
   "version": "0.0.0",
   "description": "Node.js Addons Example #9",
+  "homepage": "https://github.com/nthjelme/nodejs-domino",
   "main": "addon.js",
   "private": true,
   "gypfile": true,
   "dependencies": {
     "nan": "*"
+  },
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/nthjelme/nodejs-domino.git"
   }
 }


### PR DESCRIPTION
This way, your [npm package](https://www.npmjs.com/package/domino-nsf) will reflect this GitHub repo as the source git repo, which populates a field on npmjs.com to provide a link.
