### PR TITLE
npm script for commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Nodejs driver for Domino nsf databases",
   "homepage": "https://github.com/nthjelme/nodejs-domino",
   "scripts": {
+      "commit": "git-cz",
       "test": "mocha index.test.js"
   },
   "private": true,


### PR DESCRIPTION
Establishes commit script, `npm run commit`, so a user doesn't require commitizen be installed
globally.